### PR TITLE
Update to Blender 2.80

### DIFF
--- a/blender_optix_denoiser.py
+++ b/blender_optix_denoiser.py
@@ -1,5 +1,7 @@
 bl_info = {
-    'name': 'OptiX denoising for Blender',
+    'name': 'OptiX denoising for Blender 2.80.0',
+    "version": (1, 1, 1),
+    "blender": (2, 80, 0),
     'category': 'Render'
 }
  

--- a/blender_optix_denoiser.py
+++ b/blender_optix_denoiser.py
@@ -3,12 +3,14 @@ bl_info = {
     'category': 'Render'
 }
  
+import ntpath
+import os
+import subprocess
+
+import numpy
+
 import bpy
 import bpy.utils.previews
-import os
-import numpy
-import subprocess
-import ntpath
 
 custom_icons = None
 script_path = None
@@ -295,4 +297,3 @@ def unregister() :
         print("Unable to unregister the class \"optix_denoising_panel\"")
 
 if __name__ == "__main__" :
-    register()

--- a/blender_optix_denoiser.py
+++ b/blender_optix_denoiser.py
@@ -26,7 +26,6 @@ def load_icons():
     print("Icon dir: " + icons_dir)
     custom_icons.load("optix_icon", os.path.join(icons_dir, "optix_logo.png"), 'IMAGE')
     print("OptiX logo path:" + os.path.join(icons_dir, "optix_logo.png"))
-    bpy.utils.register_module(__name__)
 
 def denoise_animation_frame(noisy_frame_path = ""):
     denoiser_path = os.path.abspath(os.path.join(os.path.dirname(script_path), "Denosier_v2.1")) + "\Denoiser.exe"

--- a/blender_optix_denoiser.py
+++ b/blender_optix_denoiser.py
@@ -1,7 +1,7 @@
 bl_info = {
     'name': 'OptiX denoising for Blender 2.80.0',
-    "version": (1, 1, 1),
-    "blender": (2, 80, 0),
+    'version': (1, 1, 1),
+    'blender': (2, 80, 0),
     'category': 'Render'
 }
  

--- a/blender_optix_denoiser.py
+++ b/blender_optix_denoiser.py
@@ -298,3 +298,4 @@ def unregister() :
         print("Unable to unregister the class \"optix_denoising_panel\"")
 
 if __name__ == "__main__" :
+    register()

--- a/blender_optix_denoiser.py
+++ b/blender_optix_denoiser.py
@@ -47,7 +47,7 @@ def denoise_animation_frame(noisy_frame_path = ""):
 def show_message_box(message = "", title = "OptiX Denoising", icon = 'INFO'):
 
     def draw(self, context):
-        self.layout.label(message)
+        self.layout.label(text=message)
 
     bpy.context.window_manager.popup_menu(draw, title = title, icon = icon)
 

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,9 @@
 <p>
 	Tested on Windows 8.1 64 bits, with Blender 2.79. 
 </p>
+<p>
+    Tested on Windows 10 x64 with Blender 2.80.0 Beta x64 (9149e894210)
+</p>
 
 <p>
 	<b>Developpers</b>, if you want to modify this addon, I recommend you to download the release directly, for the script will be the same as on this 

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@
     <li>Add-ons</li>
 	<li>Install Add-on from File...</li>
 	<li>Select donwloaded blender_optix_denoiser.zip</li>
+	<li>Enable installed addon</li>
     <li>Render panel now has OptiX Denoising section at the bottom</li>
 </ul>
 

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,9 @@
 	sample image will result in strange results.
 </p>
 <br/>
+<p>
+<b>Works on both versions: 2.79 and 2.80 Beta</b> (thanks to Roman Kornev (https://github.com/RomanKornev/)) 
+</p>
 <br/>
 <p>
 	<b><u>DOWNLOAD LINK:</u></b>https://drive.google.com/open?id=10WNZuG4oaMIyLn0Klay7_DpZw5GzYHGF
@@ -46,9 +49,22 @@
 <p>
     Tested on Windows 10 x64 with Blender 2.80.0 Beta x64 (9149e894210)
 </p>
+<p>
+    Tested on Windows 10 x64 with Blender 2.79.6 x64
+</p>
+
+<b><u>INSTALLATION</u></b>
+<ul>
+	<li>Download zip archive</li>
+	<li>Open Blender User Preferences</li>
+    <li>Add-ons</li>
+	<li>Install Add-on from File...</li>
+	<li>Select donwloaded blender_optix_denoiser.zip</li>
+    <li>Render panel now has OptiX Denoising section at the bottom</li>
+</ul>
 
 <p>
-	<b>Developpers</b>, if you want to modify this addon, I recommend you to download the release directly, for the script will be the same as on this 
+	<b>Developers</b>, if you want to modify this addon, I recommend you to download the release directly, for the script will be the same as on this 
 	repository, and it will directly include the executable, which is not on the repository. The denoiser executable and all its dependencies must be
 	in the "Denosier_v2.1" folder, which is placed in the same folder as the script, like this:
 	<ul>


### PR DESCRIPTION
Hey @troopy28!
I updated your code to support the new Blender 2.80.0 version.
It now works on both 2.79 and 2.80.
I also added installation instructions to Readme.

If you want to merge these changes, don't forget to update your `blender_optix_denoiser.py` in Google Drive link as well.